### PR TITLE
Example book title error

### DIFF
--- a/recipes/4_higher_level_data_structures/implement_tags_and_search_them/recipe.md
+++ b/recipes/4_higher_level_data_structures/implement_tags_and_search_them/recipe.md
@@ -10,7 +10,7 @@ as 'tags'
 
 In redis-cli:
 
-    SET book:1 {'title' : 'Diving into Python',
+    SET book:1 {'title' : 'Dive into Python',
     'author': 'Mark Pilgrim'}
     SET book:2 { 'title' : 'Programing Erlang',
     'author': 'Joe Armstrong'}


### PR DESCRIPTION
Mark Pilgrim's book is called Dive into Python, not Diving into Python.
