### PR TITLE
Fixing a tag name in 'Implement tags and search them'

### DIFF
--- a/recipes/4_higher_level_data_structures/implement_tags_and_search_them/recipe.md
+++ b/recipes/4_higher_level_data_structures/implement_tags_and_search_them/recipe.md
@@ -21,7 +21,7 @@ In redis-cli:
     SADD tag:erlang 2
     SADD tag:haskell 3
     SADD tag:programming 1 2 3
-    SADD tag computing 1 2 3
+    SADD tag:computing 1 2 3
     SADD tag:distributedcomputing 2
     SADD tag:FP 2 3
 


### PR DESCRIPTION
This is a small typo fix for a tag name.

The following command would return 'empty set' otherwise:

``` bash
SINTER 'tag:programming' 'tag:computing'
```
